### PR TITLE
Prepare 1.0.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 - No changes yet.
 
+## [1.0.5] - 2025-09-08
+
+### Changed
+- Bumped application metadata and user-facing documentation to version 1.0.5 in preparation for release.
+
+### Fixed
+- Tidied release documentation to ensure the README and manuals reflect the current build details.
+
 ## [1.0.4] - 2025-09-07
 
 ### Added

--- a/FUNCTIONAL_MANUAL.md
+++ b/FUNCTIONAL_MANUAL.md
@@ -1,4 +1,4 @@
-# Functional Manual: 7-Zip GUI v1.0.4
+# Functional Manual: 7-Zip GUI v1.0.5
 
 This guide explains how to use the 7-Zip GUI application for a wide range of archiving tasks.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# 7-Zip GUI - v1.0.4
+# 7-Zip GUI - v1.0.5
 
 A modern, powerful, and complete graphical user interface for the 7-Zip command-line tool. Built with Electron, React, and TypeScript, this application provides a comprehensive and intuitive way to handle all your file compression and archiving needs.
 

--- a/TECHNICAL_MANUAL.md
+++ b/TECHNICAL_MANUAL.md
@@ -1,4 +1,4 @@
-# Technical Manual: 7-Zip GUI v1.0.4
+# Technical Manual: 7-Zip GUI v1.0.5
 
 This document outlines the technical architecture of the 7-Zip GUI application, which is designed to be a flexible and extensible front-end for the 7-Zip CLI.
 

--- a/components/AboutDialog.tsx
+++ b/components/AboutDialog.tsx
@@ -11,7 +11,7 @@ const AboutDialog: React.FC<AboutDialogProps> = ({ isOpen, onClose }) => {
         <Modal isOpen={isOpen} onClose={onClose} title="About 7-Zip GUI">
             <div className="text-center text-slate-700 dark:text-slate-300 p-6 space-y-4">
                 <h3 className="text-2xl font-bold text-slate-800 dark:text-slate-100">7-Zip GUI</h3>
-                <p className="text-sm text-slate-500 dark:text-slate-400">Version 1.0.4</p>
+                <p className="text-sm text-slate-500 dark:text-slate-400">Version 1.0.5</p>
                 
                 <div className="space-y-1 pt-4">
                     <p>Design and concept by <span className="font-semibold">Tim Sinaeve</span></p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "7zip-gui",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A GUI for 7zip on Windows",
   "main": "dist/main.cjs",
   "type": "module",


### PR DESCRIPTION
## Summary
- bump the application version to 1.0.5 across package metadata and the in-app about dialog
- refresh README and manuals so documentation reflects the new release
- add 1.0.5 entry to the changelog describing documentation updates

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dff51371cc83329491721d98312dc5